### PR TITLE
Long-term running crash 

### DIFF
--- a/example/flying_gazebo_stereo_cam/model/flying_stereo_cam.xacro
+++ b/example/flying_gazebo_stereo_cam/model/flying_stereo_cam.xacro
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <robot name="flying_stereo_cam" xmlns:xacro="http://www.ros.org/wiki/xacro">
-        
+
   <xacro:property name="PI" value="3.1415926535897931"/>
 
   <xacro:property name="cameraSize" value="0.05"/>
   <xacro:property name="cameraMass" value="0.1"/>
-  
+
   <xacro:include filename="$(find flying_gazebo_stereo_cam)/model/flying_stereo_cam.gazebo" />
   <xacro:include filename="$(find flying_gazebo_stereo_cam)/model/materials.xacro" />
   <xacro:include filename="$(find flying_gazebo_stereo_cam)/model/macros.xacro" />
-  
-  
-  
+
+
+
   <link name="base" />
-    
+
     <joint name="base_fix" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0" />
       <parent link="base"/>
@@ -54,7 +54,7 @@
       <collision>
 	<origin xyz="0 0 0" rpy="0 0 0"/>
 	<geometry>
-	  <box size="${cameraSize*2*0} ${cameraSize*0} ${cameraSize*0}"/>
+	  <box size="${cameraSize*2} ${cameraSize} ${cameraSize}"/>
 	</geometry>
       </collision>
 
@@ -72,6 +72,5 @@
 	<box_inertia m="${cameraMass*2}" x="${cameraSize}" y="${cameraSize}" z="${cameraSize}" />
       </inertial>
     </link>
-  
-</robot>
 
+</robot>

--- a/ig_active_reconstruction_octomap/include/ig_active_reconstruction_octomap/octomap_ig_tree.hpp
+++ b/ig_active_reconstruction_octomap/include/ig_active_reconstruction_octomap/octomap_ig_tree.hpp
@@ -23,13 +23,13 @@
 
 namespace ig_active_reconstruction
 {
-  
+
 namespace world_representation
 {
 
 namespace octomap
 {
-  
+
   /*! Occupancy OcTree class that uses our IgTreeNode class
    * as node type
    */
@@ -37,14 +37,14 @@ namespace octomap
   {
   public:
     typedef IgTreeNode NodeType;
-    
+
     /*! Configuration for the IgTree
      */
     struct Config
     {
     public:
       Config();
-      
+
     public:
       double resolution_m; //! OcTree leaf node size, default: 0.1 [m].
       double occupancy_threshold; //! Occupancy probability over which nodes are considered occupied, default: 0.5 [range 0-1].
@@ -53,11 +53,11 @@ namespace octomap
       double clamping_threshold_min; //! Min probability threshold over which the probability is clamped, default: 0.12, range [0-1].
       double clamping_threshold_max; //! Max probability threshold over which the probability is clamped, default: 0.97, range [0-1].
     };
-    
+
   public:
     //! Default constructor, sets resolution of leafs
     IgTree(double resolution_m);
-    
+
     /*! Constructor with complete configuration
      */
     IgTree(Config config);
@@ -68,16 +68,35 @@ namespace octomap
     IgTree* create() const;
 
     std::string getTreeType() const;
-    
+
     /*! Returns the current configuration.
      */
     const Config& config() const;
-    
+
+    /**
+     * @return mean of all children's occupancy probabilities, in log odds
+     */
+    double getMeanChildLogOdds(IgTreeNode* node) const;
+
+    /**
+     * @return maximum of children's occupancy probabilities, in log odds
+     */
+    float getMaxChildLogOdds(IgTreeNode* node) const;
+
+    /// update this node's occupancy according to its children's maximum occupancy
+    inline void updateOccupancyChildren(IgTreeNode* node)
+    {
+      node->setLogOdds(node->getMaxChildLogOdds());  // conservative
+    }
+
+    void expandNode(IgTreeNode* node);
+    bool pruneNode(IgTreeNode* node);
+
   protected:
     /*! Sets octree options based on current configuration
      */
     void updateOctreeConfig();
-    
+
   protected:
     Config config_;
 
@@ -90,16 +109,16 @@ namespace octomap
     class StaticMemberInitializer{
     public:
     StaticMemberInitializer() {
-	IgTree* tree = new IgTree(0.1);
-	AbstractOcTree::registerTreeType(tree);
+      IgTree* tree = new IgTree(0.1);
+    	AbstractOcTree::registerTreeType(tree);
     }
     };
     //! to ensure static initialization (only once)
     static StaticMemberInitializer igTreeMemberInit;
 
   };
-  
-  
+
+
 }
 
 }


### PR DESCRIPTION
Dear Jeff, 
  Thank you for this awesome stack. When we are testing the code, e.g. transfer to 864 candidate views set in both the Kinect version and the Indigo version, with corresponding 864 reconstruction steps, on a specific reconstruction step, the code breaks by 1) failing to receive the pcl data so the demanding data command receives no response.  2) Kinetic: cannot get camera pose when moving to NBV in the 281th iteration. The flying_stereo_cam node breaks up directly. 

  When we are testing the random sampling which takes several hours to update the free voxel, along with the occupied voxel, this stack cannot run long time. 

  Thank you. 
  
  Both bugs terminate the reconstruction process in the long run in both ROS versions. 
![170501078](https://user-images.githubusercontent.com/23110096/59985859-31a9d880-9677-11e9-9382-9a083f6e3b3b.jpg)
![webwxgetmsgimg](https://user-images.githubusercontent.com/23110096/59986054-45a20a00-9678-11e9-9140-c4e9f48eb80b.jpg)
